### PR TITLE
[Editorial] aboriginies → aborigines

### DIFF
--- a/src/epub/text/a.xhtml
+++ b/src/epub/text/a.xhtml
@@ -221,7 +221,7 @@
 					<p>The quality of another’s opinions.</p>
 				</dd>
 				<dt class="noun-plural">
-					<dfn>Aboriginies</dfn>
+					<dfn>Aborigines</dfn>
 				</dt>
 				<dd>
 					<ol>


### PR DESCRIPTION
This is the only instance with this spelling in the corpus; everything else uses aborigines. Not a pun or joke, as far as I can tell.